### PR TITLE
Set flag true to ignore global offset to fix section box position

### DIFF
--- a/src/public/js/extensions/SectionBoxTest.js
+++ b/src/public/js/extensions/SectionBoxTest.js
@@ -21,7 +21,7 @@ AAA.Extension.SectionBoxTest = function(viewer, options) {
         const model = models[0];
 
         const sbext = _self.viewer.getExtension('Autodesk.Section');
-        const sectionTool = sbext.tool.getSectionBoxValues();
+        const sectionTool = sbext.tool.getSectionBoxValues(true);
         const sb = sectionTool.sectionBox;
         const sbt = sectionTool.sectionBoxTransform;
 


### PR DESCRIPTION
Since the model has been applied a global offset by default, we have to pass true to the `getSectionBoxValues()` to obtain the offsetted position of the section box.